### PR TITLE
Tweaks for the new cee-rhel6 CUDA builds (ATDV-272)

### DIFF
--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_dbg.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_dbg.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=Experimental
+export Trilinos_TRACK=Specialized
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=Experimental
+export Trilinos_TRACK=Specialized
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh
@@ -1,7 +1,18 @@
 #!/bin/bash -l
 
-if [ "${Trilinos_CTEST_DO_ALL_AT_ONCE}" == "" ] ; then
-  export Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE
+set +x
+
+source $WORKSPACE/Trilinos/cmake/std/atdm/load-env.sh $JOB_NAME
+
+if [[ "${Trilinos_SKIP_CTEST_ADD_TEST}" == "" ]] && \
+   [[ "${ATDM_CONFIG_USE_CUDA}" == "ON" ]] \
+  ; then
+  # For CUDA builds, do not run the the test and example executables to speed
+  # things up and to allow us to build and install on CEE machines that don't
+  # actaully have a GPU!
+  export Trilinos_SKIP_CTEST_ADD_TEST=ON
+  # NOTE: If building the tests and examples is too expensive, we could set
+  # Trilinos_INNER_ENABLE_TESTS=OFF.
 fi
 
 set -x

--- a/cmake/std/atdm/cee-rhel6/all_supported_builds.sh
+++ b/cmake/std/atdm/cee-rhel6/all_supported_builds.sh
@@ -9,7 +9,11 @@ export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
   cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt        # SPARC CI build
   cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt   # SPARC Nightly bulid
   cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt # SPARC CI build
+  cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_dbg # SPARC CI build
   )
 
 # NOTE: Above, we have commented out the 'dbg' build because it was running
 # the test suite very slow and had many timeouts (see ATDV-322)
+
+# NOTE: The cuda builds should not be running any tests so it is fine to do
+# those builds on any of the CEE machines, even those that don't have a GPU!


### PR DESCRIPTION
This makes it so that the new CUDA builds only build the libraries, tests, and examples but does not actually run any tests. 

I also elevated these builds from 'Experimental' to 'Specialized' which I think is pretty safe (see argument below).

## How was this tested

To test this, on 'ceerws1113', I built Kokkos with tests an examples on 'ceerws1113' with:

```
$ cd /home/rabartl/Trilinos.base/BUILDS/ATDM/CEE-RHEL6/CTEST_S/

$ env \
    Trilinos_PACKAGES=KokkosCore,TeuchosCore \
    Trilinos_SKIP_CTEST_ADD_TEST=OFF \
  ./ctest-s-local-test-driver-cee-rhel6.sh \
    cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt


***
*** /home/rabartl/Trilinos.base/Trilinos/cmake/std/atdm/ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'ceerws1113' matches known ATDM host 'ceerws1113' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-default'
Using CEE RHEL6 compiler stack CLANG-9.0.1_OPENMPI-4.0.3 to build DEBUG code with Kokkos node type SERIAL

Running builds:
    cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt

Wed Jul  1 16:50:45 MDT 2020

Running Jenkins driver Trilinos-atdm-cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt.sh ...

    See log file Trilinos-atdm-cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt/smart-jenkins-driver.out

real    2m38.498s
user    5m42.311s
sys     1m33.176s

82% tests passed, 31 tests failed out of 173

Wed Jul  1 16:53:23 MDT 2020

Done running all of the builds!
```

where:

```
$ cat ctest-s-local-test-driver-cee-rhel6.sh
#!/bin/bash
env ATDM_CTEST_S_DEFAULT_ENV=cee-rhel6-default \
/home/rabartl/Trilinos.base/Trilinos/cmake/std/atdm/ctest-s-local-test-driver.sh "$@"
```

Then on the machine 'ascicgpu16' I did:

```
$ cd /home/rabartl/Trilinos.base/BUILDS/ATDM/CEE-RHEL6/CTEST_S/Trilinos-atdm-cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt

$ cd SRC_AND_BUILD/BUILD/

$ . ~/Trilinos.base/Trilinos/cmake/std/atdm/load-env.sh cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt
Hostname 'ascicgpu16' matches known ATDM host 'ascicgpu16' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt'
Using CEE RHEL6 compiler stack CUDA-10.1.243_GCC-7.2.0_OPENMPI-4.0.3 to build RELEASE code with Kokkos node type CUDA
Creating /tmp/rabartl for nvcc wrapper!

$ cd packages/kokkos/

$ time ctest &> ctest.out ; grep -A 100 "failed out of" ctest.out

real    7m18.578s
user    1m3.682s
sys     0m37.477s
94% tests passed, 2 tests failed out of 31

Label Time Summary:
Kokkos    = 438.37 sec*proc (31 tests)

Total Test time (real) = 438.55 sec

The following tests FAILED:
          5 - KokkosCore_UnitTest_Default_MPI_1 (Failed)
         25 - KokkosCore_IncrementalTest_CUDA_MPI_1 (Failed)
Errors while running CTest
```

Okay, that is pretty good evidence that this is working.  You can build with CUDA for the GPU on a machine that does not have a GPU and you can run on a machine with a GPU.

The test {{KokkosCore_UnitTest_Default_MPI_1}} failed with the error:

```
----------------------------------------------------------
[0;32m[==========] [mRunning 13 tests from 2 test cases.
[0;32m[----------] [mGlobal test environment set-up.
[0;32m[----------] [m1 test from kokkosresize
[0;32m[ RUN      ] [mkokkosresize.host_space_access
[0;32m[       OK ] [mkokkosresize.host_space_access (31 ms)
[0;32m[----------] [m1 test from kokkosresize (31 ms total)

[0;32m[----------] [m12 tests from defaultdevicetype
[0;32m[ RUN      ] [mdefaultdevicetype.test_utilities
[0;32m[       OK ] [mdefaultdevicetype.test_utilities (0 ms)
[0;32m[ RUN      ] [mdefaultdevicetype.malloc
[0;32m[       OK ] [mdefaultdevicetype.malloc (1 ms)
[0;32m[ RUN      ] [mdefaultdevicetype.reduce_instantiation_c3
--------------------------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
--------------------------------------------------------------------------
--------------------------------------------------------------------------
mpirun noticed that process rank 0 with PID 0 on node ascicgpu16 exited on signal 11 (Segmentation fault).
--------------------------------------------------------------------------
```

The test {{KokkosCore_IncrementalTest_CUDA_MPI_1}} failed with:

```
----------------------------------------------------------
[0;32m[==========] [mRunning 25 tests from 1 test case.
[0;32m[----------] [mGlobal test environment set-up.
[0;32m[----------] [m25 tests from CUDA
[0;32m[ RUN      ] [mCUDA.IncrTest_13c_Hierarchical_Red
[0;32m[       OK ] [mCUDA.IncrTest_13c_Hierarchical_Red (3 ms)
[0;32m[ RUN      ] [mCUDA.IncrTest_13b_Hierarchical_Red
[0;32m[       OK ] [mCUDA.IncrTest_13b_Hierarchical_Red (2 ms)
[0;32m[ RUN      ] [mCUDA.IncrTest_13a_Hierarchical_Red
[0;32m[       OK ] [mCUDA.IncrTest_13a_Hierarchical_Red (3 ms)
[0;32m[ RUN      ] [mCUDA.IncrTest_12b_TeamScratch
unknown file: Failure
C++ exception with description "Kokkos failed to allocate memory for label "CudaSpace::ScratchMemory".  Allocation using MemorySpace named "Cuda" failed with the following error:  Allocation of size 1.696 G failed, likely due to insufficient memory.  (The allocation mechanism was cudaMalloc().  The Cuda allocation returned the error code ""cudaErrorMemoryAllocation".)

Traceback functionality not available
" thrown in the test body.
[0;31m[  FAILED  ] [mCUDA.IncrTest_12b_TeamScratch (3 ms)
[0;32m[ RUN      ] [mCUDA.IncrTest_12a_ThreadScratch
terminate called after throwing an instance of 'std::runtime_error'
  what():  cudaDeviceSynchronize() error( cudaErrorIllegalAddress): an illegal memory access was encountered /ascldap/users/rabartl/Trilinos.base/BUILDS/ATDM/CEE-RHEL6/CTEST_S/Trilinos-atdm-cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt/SRC_AND_BUILD/Trilinos/packages/kokkos/core/src/Cuda/Kokkos_Cuda_Instance.cpp:143
Traceback functionality not available

--------------------------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
--------------------------------------------------------------------------
--------------------------------------------------------------------------
mpirun noticed that process rank 0 with PID 0 on node ascicgpu16 exited on signal 6 (Aborted).
--------------------------------------------------------------------------
```

Not sure what is going on there.

Now to run the ctest-s driver again, but this time letting it use the default with no tests on 'ceerws1113':

```
$ cd /home/rabartl/Trilinos.base/BUILDS/ATDM/CEE-RHEL6/CTEST_S/

$ env Trilinos_PACKAGES=KokkosCore,TeuchosCore \
  ./ctest-s-local-test-driver-cee-rhel6.sh \
    cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt

***
*** /home/rabartl/Trilinos.base/Trilinos/cmake/std/atdm/ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'ceerws1113' matches known ATDM host 'ceerws1113' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-default'
Using CEE RHEL6 compiler stack CLANG-9.0.1_OPENMPI-4.0.3 to build DEBUG code with Kokkos node type SERIAL

Running builds:
    cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt

Wed Jul  1 17:28:18 MDT 2020

Running Jenkins driver Trilinos-atdm-cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt.sh ...

    See log file Trilinos-atdm-cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt/smart-jenkins-driver.out

real    2m6.219s
user    5m23.489s
sys     1m21.444s


Wed Jul  1 17:30:24 MDT 2020

Done running all of the builds!
```

That posted to CDash:

* https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=61&value1=Trilinos-atdm-cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt-exp&field2=buildstamp&compare2=61&value2=20200701-2328-Experimental

and it showed 0 tests run.

This looks ready to go.
