### PR TITLE
Run CUDA builds only on 'ascicgpu' machines (ATDV-272)

### DIFF
--- a/cmake/std/atdm/cee-rhel6/all_supported_builds.sh
+++ b/cmake/std/atdm/cee-rhel6/all_supported_builds.sh
@@ -2,18 +2,29 @@
 
 export ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX=Trilinos-atdm-
 
-export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
-  #cee-rhel6_clang-9.0.1_openmpi-4.0.3_serial_static_dbg    # SPARC has installs with this build
-  cee-rhel6_clang-9.0.1_openmpi-4.0.3_serial_static_opt      # SPARC CI build
-  cee-rhel6_gnu-7.2.0_openmpi-4.0.3_serial_shared_opt        # SPARC CI build
-  cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt        # SPARC CI build
-  cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt   # SPARC Nightly bulid
-  cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt # SPARC CI build
-  cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_dbg # SPARC CI build
-  )
+HOSTNAME=$(hostname)
+
+if [[ "${HOSTNAME}" == "ascicgpu"* ]] ; then
+  export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
+    cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt # SPARC Nightly build
+    cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_dbg # SPARC Nightly build
+    )
+else
+  export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
+    #cee-rhel6_clang-9.0.1_openmpi-4.0.3_serial_static_dbg    # SPARC has installs with this build
+    cee-rhel6_clang-9.0.1_openmpi-4.0.3_serial_static_opt      # SPARC CI build
+    cee-rhel6_gnu-7.2.0_openmpi-4.0.3_serial_shared_opt        # SPARC CI build
+    cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt        # SPARC CI build
+    cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt   # SPARC Nightly bulid
+    )
+fi
 
 # NOTE: Above, we have commented out the 'dbg' build because it was running
 # the test suite very slow and had many timeouts (see ATDV-322)
 
-# NOTE: The cuda builds should not be running any tests so it is fine to do
-# those builds on any of the CEE machines, even those that don't have a GPU!
+# NOTE: You have to run the CEE CUDA builds on an 'ascicgpu' machine or they
+# generate binaries that don't work for the 'ascicgpu' machines.  At the same
+# time, the 'ascicgpu' machines are a coveted resource so we don't want to
+# waste an 'ascicgpu' machine with builds that don't even require running on
+# the GPU.  So to run the non CUDA-builds, get on a CEE machine that does not
+# have a GPU and to run the CUDA builds, get on an 'ascicgpu' machine.


### PR DESCRIPTION
## How was this tested?

On 'ceerws1113', I ran:

```
$  env Trilinos_PACKAGES=KokkosCore,TeuchosCore ./ctest-s-local-test-driver-cee-rhel6.sh

***
*** /home/rabartl/Trilinos.base/Trilinos/cmake/std/atdm/ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'ceerws1113' matches known ATDM host 'ceerws1113' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-default'
Using CEE RHEL6 compiler stack CLANG-9.0.1_OPENMPI-4.0.3 to build DEBUG code with Kokkos node type SERIAL

Error, must provide 'all' or a list of supported build names which include:

    Trilinos-atdm-cee-rhel6_clang-9.0.1_openmpi-4.0.3_serial_static_opt
    Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-4.0.3_serial_shared_opt
    Trilinos-atdm-cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt
    Trilinos-atdm-cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt

See --help for more details!
```


On 'ascicgpu16' I ran:

```
$ env Trilinos_PACKAGES=KokkosCore,TeuchosCore ./ctest-s-local-test-driver-cee-rhel6.sh

***
*** /home/rabartl/Trilinos.base/Trilinos/cmake/std/atdm/ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'ascicgpu16' matches known ATDM host 'ascicgpu16' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-default'
Using CEE RHEL6 compiler stack CLANG-9.0.1_OPENMPI-4.0.3 to build DEBUG code with Kokkos node type SERIAL

Error, must provide 'all' or a list of supported build names which include:

    Trilinos-atdm-cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_opt
    Trilinos-atdm-cee-rhel6_cuda-10.1.243_gcc-7.2.0_openmpi-4.0.3_shared_dbg

See --help for more details!
```



