### PR TITLE
Hopefuly final tweaks to 'ats2' 'xl' ctest -S builds (CDOFA-92)

### DIFF
--- a/cmake/ctest/drivers/atdm/TrilinosCTestDriverCore.atdm.cmake
+++ b/cmake/ctest/drivers/atdm/TrilinosCTestDriverCore.atdm.cmake
@@ -83,6 +83,7 @@ MACRO(TRILINOS_SYSTEM_SPECIFIC_CTEST_DRIVER)
   PRINT_VAR(ATDM_CONFIGURE_OPTIONS_FILES)
 
   MESSAGE("Include the configure options files at the top level to influence what package get enabled or disabled ...")
+  SPLIT("${ATDM_CONFIGURE_OPTIONS_FILES}" "," ATDM_CONFIGURE_OPTIONS_FILES)
   FOREACH (CONFIG_OPTIONS_FILE ${ATDM_CONFIGURE_OPTIONS_FILES})
     SET(CONFIG_OPTIONS_FILE "${TRIBITS_PROJECT_ROOT}/${CONFIG_OPTIONS_FILE}")
     MESSAGE("Including ${CONFIG_OPTIONS_FILE} ...")
@@ -93,15 +94,17 @@ MACRO(TRILINOS_SYSTEM_SPECIFIC_CTEST_DRIVER)
   STRING(REGEX MATCH "panzer" ATDM_PANZER_IN_JOB_NAME
     "${CTEST_BUILD_NAME}" )
 
-  IF (ATDM_ENABLE_ALL_PACKAGES)
+  IF (NOT "${Trilinos_PACKAGES}" STREQUAL "")
+    MESSAGE("Trilinos_PACKAGES is aleady set so use it!")
+  ELSEIF (ATDM_ENABLE_ALL_PACKAGES)
     MESSAGE("Enabling all packages by default!")
-    SET(Trilinos_PACKAGES)
+    SET(Trilinos_PACKAGES "")
   ELSEIF (ATDM_PANZER_IN_JOB_NAME)
     MESSAGE("Found 'panzer' in JOB_NAME, enabling only Panzer tests")
     SET(Trilinos_PACKAGES Panzer)
   ELSE()
     MESSAGE("Enabling all packages not otherwise disabled!")
-    SET(Trilinos_PACKAGES)
+    SET(Trilinos_PACKAGES "")
     # Implicitly allow the enable of all packages that are not otherwise
     # disabled by the (indirect) include of ATDMDisables.cmake.
   ENDIF()

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_dbg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Experimental
+  export Trilinos_TRACK=ATDM
 fi
 
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_dbg.sh
@@ -3,14 +3,4 @@ if [ "${Trilinos_TRACK}" == "" ] ; then
   export Trilinos_TRACK=Experimental
 fi
 
-if [[ "${Trilinos_INNER_ENABLE_TESTS}" == "" ]]; then
-  # For XL, do not build tests and examples
-  export Trilinos_INNER_ENABLE_TESTS=OFF
-fi
-
-if [[ "${Trilinos_SKIP_CTEST_ADD_TEST}" == "" ]] ; then
-  # For XL, do not run tests
-  export Trilinos_SKIP_CTEST_ADD_TEST=TRUE
-fi
-
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Experimental
+  export Trilinos_TRACK=ATDM
 fi
 
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt.sh
@@ -3,14 +3,4 @@ if [ "${Trilinos_TRACK}" == "" ] ; then
   export Trilinos_TRACK=Experimental
 fi
 
-if [[ "${Trilinos_INNER_ENABLE_TESTS}" == "" ]]; then
-  # For XL, do not build tests and examples
-  export Trilinos_INNER_ENABLE_TESTS=OFF
-fi
-
-if [[ "${Trilinos_SKIP_CTEST_ADD_TEST}" == "" ]] ; then
-  # For XL, do not run tests
-  export Trilinos_SKIP_CTEST_ADD_TEST=TRUE
-fi
-
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-xl-2020.03.18_spmpi-rolling_serial_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-xl-2020.03.18_spmpi-rolling_serial_static_dbg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Experimental
+  export Trilinos_TRACK=ATDM
 fi
 
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-xl-2020.03.18_spmpi-rolling_serial_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-xl-2020.03.18_spmpi-rolling_serial_static_dbg.sh
@@ -3,14 +3,4 @@ if [ "${Trilinos_TRACK}" == "" ] ; then
   export Trilinos_TRACK=Experimental
 fi
 
-if [[ "${Trilinos_INNER_ENABLE_TESTS}" == "" ]]; then
-  # For XL, do not build tests and examples
-  export Trilinos_INNER_ENABLE_TESTS=OFF
-fi
-
-if [[ "${Trilinos_SKIP_CTEST_ADD_TEST}" == "" ]] ; then
-  # For XL, do not run tests
-  export Trilinos_SKIP_CTEST_ADD_TEST=TRUE
-fi
-
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-xl-2020.03.18_spmpi-rolling_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-xl-2020.03.18_spmpi-rolling_serial_static_opt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Experimental
+  export Trilinos_TRACK=ATDM
 fi
 
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-xl-2020.03.18_spmpi-rolling_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-xl-2020.03.18_spmpi-rolling_serial_static_opt.sh
@@ -3,14 +3,4 @@ if [ "${Trilinos_TRACK}" == "" ] ; then
   export Trilinos_TRACK=Experimental
 fi
 
-if [[ "${Trilinos_INNER_ENABLE_TESTS}" == "" ]]; then
-  # For XL, do not build tests and examples
-  export Trilinos_INNER_ENABLE_TESTS=OFF
-fi
-
-if [[ "${Trilinos_SKIP_CTEST_ADD_TEST}" == "" ]] ; then
-  # For XL, do not run tests
-  export Trilinos_SKIP_CTEST_ADD_TEST=TRUE
-fi
-
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/ats2/local-driver.sh
@@ -5,6 +5,22 @@ set +x
 # Need to load env so we define some vars
 source $WORKSPACE/Trilinos/cmake/std/atdm/load-env.sh $JOB_NAME
 
+# Make adjustments for the XL builds
+if atdm_match_buildname_keyword xl ; then
+  echo "This is an XL build!"
+  # For XL, do not build tests and examples by default.
+  if [[ "${Trilinos_INNER_ENABLE_TESTS}" == "" ]]; then
+    export Trilinos_INNER_ENABLE_TESTS=OFF
+  fi
+  # Don't do the cuda-aware build for the XL builds if you are not building
+  # internal tests and examples.
+  if [[ "${Trilinos_INNER_ENABLE_TESTS}" == "OFF" ]]; then
+    export Trilinos_CTEST_RUN_CUDA_AWARE_MPI=0
+  fi
+  # Only enable the SPARC packages by default
+  export ATDM_CONFIG_CONFIGURE_OPTIONS_FILES=cmake/std/atdm/ATDMDevEnv.cmake,cmake/std/atdm/apps/sparc/SPARC_Trilinos_PACKAGES.cmake
+fi
+
 echo
 echo "Current node type: $(atdm_ats2_get_node_type)"
 echo

--- a/cmake/std/atdm/apps/sparc/SPARC_Trilinos_PACKAGES.cmake
+++ b/cmake/std/atdm/apps/sparc/SPARC_Trilinos_PACKAGES.cmake
@@ -1,0 +1,8 @@
+# Include this file in the driver that calls TRIBITS_CTEST_DRIVER() to set the
+# list of packages used by SPARC.
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/SPARCTrilinosPackagesList.cmake")
+SET(Trilinos_PACKAGES ${SPARC_Trilinos_Packages})
+# NOTE: Above, even though SPARC_Trilinos_Packages may list a bunch of
+# packages that we don't want to test, the file ATDMDisables.cmake has
+# <Package>_ENABLE_TESTS set to OFF for all fo the packages that we don't want
+# to test.


### PR DESCRIPTION
* Only enable the packages that SPARC uses for the XL builds (to avoid Panzer build errors)
* Skip the 'cuda-aware-mpi' build for the XL builds since we don't actually run any tests for those builds.
* Consolidate logic for the XL builds into the ats2/local-driver.sh script and remove it from each of the individaul top-level XL driver scripts.
* Promote all of the new XL builds to the 'ATDM' CDash group

## How was this tested?

I tested these changes on 'vorex' in two ways.

First, I ran:

```
$ env CTEST_DO_BUILD=OFF CTEST_DO_TEST=OFF CTEST_DO_SUBMIT=ON \
  ./ctest-s-local-test-driver.sh \
    ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt \
    ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt

***
*** ./ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'vortex60' matches known ATDM host 'vortex60' and system 'ats2'
Setting compiler and build options for build-name 'default'
Using ats2 compiler stack GNU-7.3.1_SPMPI-ROLLING to build DEBUG code with Kokkos node type SERIAL

Due to MODULEPATH changes, the following have been reloaded:
  1) spectrum-mpi/rolling-release


Running builds:
    ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt
    ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt

Fri Jul 10 19:09:34 MDT 2020

Running Jenkins driver Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt.sh ...

    See log file Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt/smart-jenkins-driver.out

real    2m29.373s
user    1m17.954s
sys     0m31.023s


Fri Jul 10 19:12:03 MDT 2020

Running Jenkins driver Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt.sh ...

    See log file Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt/smart-jenkins-driver.out

real    7m56.737s
user    4m33.669s
sys     1m37.548s


Fri Jul 10 19:20:00 MDT 2020

Done running all of the builds!
```

which submitted to CDash:

* https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&filtercount=5&showfilters=1&filtercombine=and&field1=groupname&compare1=61&value1=Experimental&field2=buildname&compare2=65&value2=Trilinos-atdm-ats2&field3=buildname&compare3=63&value3=-exp&field4=buildstarttime&compare4=83&value4=2020-07-11T01%3A09%3A47%20UTC&field5=buildstarttime&compare5=84&value5=2020-07-11T01%3A16%3A12%20UTC

showing:


| Site | Build Name | Conf Err | Conf Warn | Build Err | Start Time | Labels |
| -- | -- | -- | -- | -- | -- | -- |
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt_cuda-aware-mpi-exp | 0 | 4 | 3m 35s | 31 minutes ago | (30 labels)
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt-exp | 0 | 4 | 3m 32s | 34 minutes ago | (30 labels)
vortex | Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt-exp | 0 | 4 | 2m 1s | 37 minutes ago | (15 labels)

Note that the 'cuda-xl' build only shows "15 labels" while the 'cuda-gnu' build shows "30 labels" and also shows a 'cuda-aware-mpi' build.

Second, I tested this by running:

```
$ env Trilinos_PACKAGES=Kokkos,Teuchos CTEST_DO_SUBMIT=ON \
  ./ctest-s-local-test-driver.sh \
    ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt \
    ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt

***
*** ./ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'vortex60' matches known ATDM host 'vortex60' and system 'ats2'
Setting compiler and build options for build-name 'default'
Using ats2 compiler stack GNU-7.3.1_SPMPI-ROLLING to build DEBUG code with Kokkos node type SERIAL

Due to MODULEPATH changes, the following have been reloaded:
  1) spectrum-mpi/rolling-release


Running builds:
    ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt
    ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt

Fri Jul 10 19:22:04 MDT 2020

Running Jenkins driver Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt.sh ...

    See log file Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt/smart-jenkins-driver.out

real    1m58.205s
user    2m11.767s
sys     0m38.684s


Fri Jul 10 19:24:02 MDT 2020

Running Jenkins driver Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt.sh ...

    See log file Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt/smart-jenkins-driver.out

real    26m30.722s
user    83m10.083s
sys     10m23.557s

99% tests passed, 1 tests failed out of 173
100% tests passed, 0 tests failed out of 173

Fri Jul 10 19:50:33 MDT 2020

Done running all of the builds!
```

which submitted to CDash:

* https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&filtercount=5&showfilters=1&filtercombine=and&field1=groupname&compare1=61&value1=Experimental&field2=buildname&compare2=65&value2=Trilinos-atdm-ats2&field3=buildname&compare3=63&value3=-exp&field4=buildstarttime&compare4=83&value4=2020-07-11T01%3A22%3A14%20UTC&field5=buildstarttime&compare5=84&value5=2020-07-11T01%3A42%3A29%20UTC

showing:


| Site | Build Name | Conf Err | Conf Warn | Conf Test Time | Build Err | Build Warn | Build Test Time | Test Not Run | Test Fail | Test Pass | Test Time | Test Proc Time | Start Test Time | Labels |
| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt_cuda-aware-mpi-exp | 0 | 3 | 49s | 0 | 0 | 39s | 0 | 0 | 173 | 6m 21s | 25m 8s | 10 minutes ago | (2 labels)
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt-exp | 0 | 3 | 52s | 0 | 9 | 11m 10s | 0 | 1 | 172 | 5m 50s | 23m 2s | 28 minutes ago | (2 labels)
vortex | Trilinos-atdm-ats2-cuda-10.1.243-xl-2020.03.18_spmpi-rolling_static_opt-exp | 0 | 3 | 1m 9s | 0 | 0 | 23s | 0 | 0 | 0 | 0s | 0s | 30 minutes ago | (2 labels)

These test invocation cases show the following:

* The 'gnu' builds enable and test all of the ATDM packages while the 'xl' builds only enable packages used by SPARC.

* The 'cuda-gnu' builds have two sets of builds on CDash, one for non-cuda-aware and one for cuda-aware running of the tests

* The 'xl' builds don't run any tests

This should be good to go now.
