### PR TITLE
packages/framework/ini-files: Replace clang with clang/11

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1921,7 +1921,7 @@ use RHEL7_POST
 #
 #use RHEL7_POST
 
-[rhel7_sems-clang-9.0.0-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+[rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use RHEL7_SEMS_COMPILER|CLANG
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|RELEASE-DEBUG
@@ -1943,45 +1943,47 @@ use RHEL7_TEST_DISABLES|CLANG
 
 use RHEL7_POST
 
-[rhel7_sems-clang-10.0.0-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
-use RHEL7_SEMS_COMPILER|CLANG
-use NODE-TYPE|SERIAL
-use BUILD-TYPE|RELEASE-DEBUG
-use RHEL7_SEMS_LIB-TYPE|SHARED
-use KOKKOS-ARCH|NO-KOKKOS-ARCH
-use RHEL7_SEMS_USE-ASAN|NO_USE-FPIC|NO_USE-MPI|YES_USE-PT|NO
-use USE-COMPLEX|NO
-use USE-RDC|NO
-use USE-UVM|NO
-use USE-DEPRECATED|YES
-use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
+opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 17
 
-use COMMON
+# [rhel7_sems-clang-10.0.0-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+# use RHEL7_SEMS_COMPILER|CLANG
+# use NODE-TYPE|SERIAL
+# use BUILD-TYPE|RELEASE-DEBUG
+# use RHEL7_SEMS_LIB-TYPE|SHARED
+# use KOKKOS-ARCH|NO-KOKKOS-ARCH
+# use RHEL7_SEMS_USE-ASAN|NO_USE-FPIC|NO_USE-MPI|YES_USE-PT|NO
+# use USE-COMPLEX|NO
+# use USE-RDC|NO
+# use USE-UVM|NO
+# use USE-DEPRECATED|YES
+# use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
-# TODO: Ask framework team why these mismatch...? Contradicts cmake fragment files in Trilinos/cmake/std...
-# ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_MueLu=ON -> Trilinos_ENABLE_MueLu=
-# ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACAS= -> Trilinos_ENABLE_SEACAS=ON
-# ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASAlgebra= -> Trilinos_ENABLE_SEACASAlgebra=ON
-# ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASAprepro= -> Trilinos_ENABLE_SEACASAprepro=ON
-# ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASAprepro_lib= -> Trilinos_ENABLE_SEACASAprepro_lib=ON
-# ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASEpu= -> Trilinos_ENABLE_SEACASEpu=ON
-# ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASExodiff= -> Trilinos_ENABLE_SEACASExodiff=ON
-# ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASGjoin= -> Trilinos_ENABLE_SEACASGjoin=ON
-# ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASGrepos= -> Trilinos_ENABLE_SEACASGrepos=ON
-# ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASIoss= -> Trilinos_ENABLE_SEACASIoss=ON
-# ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASSupes= -> Trilinos_ENABLE_SEACASSupes=ON
-# ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASSuplibCpp= -> Trilinos_ENABLE_SEACASSuplibCpp=ON
-# ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_Xpetra=ON -> Trilinos_ENABLE_Xpetra=
-# ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_Zoltan2=ON -> Trilinos_ENABLE_Zoltan2=
-# ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_Zoltan2Core=ON -> Trilinos_ENABLE_Zoltan2Core=
-# ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_Zoltan2Sphynx=ON -> Trilinos_ENABLE_Zoltan2Sphynx=
+# use COMMON
 
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none
-opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
+# # TODO: Ask framework team why these mismatch...? Contradicts cmake fragment files in Trilinos/cmake/std...
+# # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_MueLu=ON -> Trilinos_ENABLE_MueLu=
+# # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACAS= -> Trilinos_ENABLE_SEACAS=ON
+# # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASAlgebra= -> Trilinos_ENABLE_SEACASAlgebra=ON
+# # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASAprepro= -> Trilinos_ENABLE_SEACASAprepro=ON
+# # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASAprepro_lib= -> Trilinos_ENABLE_SEACASAprepro_lib=ON
+# # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASEpu= -> Trilinos_ENABLE_SEACASEpu=ON
+# # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASExodiff= -> Trilinos_ENABLE_SEACASExodiff=ON
+# # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASGjoin= -> Trilinos_ENABLE_SEACASGjoin=ON
+# # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASGrepos= -> Trilinos_ENABLE_SEACASGrepos=ON
+# # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASIoss= -> Trilinos_ENABLE_SEACASIoss=ON
+# # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASSupes= -> Trilinos_ENABLE_SEACASSupes=ON
+# # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_SEACASSuplibCpp= -> Trilinos_ENABLE_SEACASSuplibCpp=ON
+# # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_Xpetra=ON -> Trilinos_ENABLE_Xpetra=
+# # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_Zoltan2=ON -> Trilinos_ENABLE_Zoltan2=
+# # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_Zoltan2Core=ON -> Trilinos_ENABLE_Zoltan2Core=
+# # ../../Trilinos/build/CMakeCache.txt mismatch Trilinos_ENABLE_Zoltan2Sphynx=ON -> Trilinos_ENABLE_Zoltan2Sphynx=
 
-use RHEL7_TEST_DISABLES|CLANG
+# opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none
+# opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
 
-use RHEL7_POST
+# use RHEL7_TEST_DISABLES|CLANG
+
+# use RHEL7_POST
 
 [weaver_cuda-10.1.105-gnu-7.2.0-spmpi-rolling_release_static_Volta70_Power9_no-asan_complex_fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_pr-framework-atdm]
 use RHEL7_COMPILER|CUDA_USE-COMPLEX|YES

--- a/packages/framework/ini-files/supported-envs.ini
+++ b/packages/framework/ini-files/supported-envs.ini
@@ -151,10 +151,10 @@ sems-gnu-8.3.0-openmpi-1.10.1-openmp:
     gnu-8.3.0-openmp
 #sems-clang-7.0.1-openmpi-1.10.1-serial:
 #    clang-7.0.1
-sems-clang-9.0.0-openmpi-1.10.1-serial:
-    clang-9.0.0
-sems-clang-10.0.0-openmpi-1.10.1-serial:
-    clang-10.0.0
+sems-clang-11.0.1-openmpi-1.10.1-serial:
+    clang-11.0.1
+# sems-clang-10.0.0-openmpi-1.10.1-serial:
+#     clang-10.0.0
 # sems-intel-17.0.1-mpich-3.2-serial:
 #     intel-17.0.1
 sems-intel-19.0.5-mpich-3.2-serial:


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@srbdev @DaveBeCoding @fryeguy52 @jmlapre: Please review.

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Update to C++17 builds.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Built and tested locally:
```
$ source ../packages/framework/GenConfig/gen-config.sh rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables --cmake-fragment TRILFRAME-411.cmake ../
<snip>
(rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial) $ # Appended Trilinos_ENABLE_ALL_PACKAGES=ON to TRILFRAME-411.cmake
(rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial) $ cmake -C TRILFRAME-411.cmake ..
<snip>
(rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial) $ make -j8
<snip>
(rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial) $ ctest -j4 -V --output-on-failure
<snip>
Total Test time (real) = 2932.35 sec

The following tests FAILED:
	3452 - TrilinosInstallTests_doInstall (Failed)
	3453 - TrilinosInstallTests_find_package_Trilinos (Not Run)
	3454 - TrilinosInstallTests_simpleBuildAgainstTrilinos (Not Run)
Errors while running CTest

```

Related to [TRILFRAME-407](https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-407), [TRILFRAME-410](https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-410), and [TRILFRAME-411](https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-411).

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->