### PR TITLE
convert GCC 7.2.0 debug to to GCC 8.3.0

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1737,7 +1737,7 @@ opt-set-cmake-var CMAKE_CXX_STANDARD          STRING FORCE : 17
 
 use RHEL7_POST
 
-[rhel7_sems-gnu-7.2.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+[rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use RHEL7_SEMS_COMPILER|GNU
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|DEBUG
@@ -1752,12 +1752,13 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
 use COMMON
 
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING     : --bind-to;none
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL       : ON
-opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL       : ON
-opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL : ON
-opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_STANDARD                                     STRING FORCE : 17
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING       : --bind-to;none
+opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL         : ON
+opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
+opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL         : ON
+opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL         : ON
+opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 use RHEL7_POST
 

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1758,7 +1758,7 @@ opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL   
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
 opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL         : ON
 opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 use RHEL7_POST
 

--- a/packages/framework/ini-files/supported-envs.ini
+++ b/packages/framework/ini-files/supported-envs.ini
@@ -143,10 +143,12 @@ sems-gnu-7.2.0-python-3.6.10-serial:
     gnu-7.2.0-python-3.6.10
 sems-gnu-7.2.0-anaconda3-serial:
     gnu-7.2.0-anaconda3-nompi
-sems-gnu-7.2.0-serial:
-    gnu-7.2.0-nompi
 sems-gnu-7.2.0-openmpi-1.10.1-serial:
     gnu-7.2.0
+sems-gnu-7.2.0-serial:
+    gnu-7.2.0-nompi
+sems-gnu-8.3.0-openmpi-1.10.1-serial:
+    gnu-8.3.0
 sems-gnu-8.3.0-openmpi-1.10.1-openmp:
     gnu-8.3.0-openmp
 #sems-clang-7.0.1-openmpi-1.10.1-serial:


### PR DESCRIPTION
## Motivation

Migrating to C++17 across all compilers. Updating from gcc 7.2.0 to gcc 8.3.0 while we're doing so as gcc 7.2.0 is being retired.
