### PR TITLE
packages/framework/ini-files: Add clang-11 with all packages

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1946,6 +1946,11 @@ use RHEL7_POST
 
 opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 17
 
+[rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+use rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+use PACKAGE-ENABLES|ALL
+
+
 # [rhel7_sems-clang-10.0.0-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 # use RHEL7_SEMS_COMPILER|CLANG
 # use NODE-TYPE|SERIAL


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Needed for monitoring nightly clang-11 C++17 build.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
```
$ source ../packages/framework/GenConfig/gen-config.sh --cmake-fragment frag.cmake rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all ../
(rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial) $ cmake -C frag.cmake ../
<snip>
 -- Build files have been written to: /scratch/eharvey/Trilinos/build
(rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial) $ grep -i enable_all CMakeCache.txt 
Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES:BOOL=ON
Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON
Trilinos_ENABLE_ALL_PACKAGES:BOOL=ON
```

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
@srbdev, @jmlapre, @fryeguy52, @DaveBeCoding: Please review. We will need this same change for all other C++17 builds.