### PR TITLE
packages/framework/ini-files: add GCC 8.3.0 serial with all packages

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1762,7 +1762,7 @@ opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING 
 
 use RHEL7_POST
 
-[rhel7_sems-gnu-7.2.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+[rhel7_sems-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use RHEL7_SEMS_COMPILER|GNU
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|RELEASE-DEBUG
@@ -1777,12 +1777,17 @@ use USE-DEPRECATED|YES
 
 use COMMON_USE-MPI|NO
 
-opt-set-cmake-var Trilinos_ENABLE_Fortran OFF BOOL : OFF
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE BOOL : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
-opt-set-cmake-var TPL_ENABLE_ParMETIS BOOL FORCE : OFF
+opt-set-cmake-var CMAKE_CXX_STANDARD             STRING FORCE : 17
+opt-set-cmake-var Trilinos_ENABLE_Fortran OFF    BOOL         : OFF
+opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE BOOL         : ON
+opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var TPL_ENABLE_ParMETIS            BOOL FORCE   : OFF
 
 use RHEL7_POST
+
+[rhel7_sems-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-all]
+user rhel7_sems-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+use PACKAGE-ENABLES|ALL
 
 [rhel7_sems-gnu-7.2.0-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_pr]
 use RHEL7_SEMS_COMPILER|GNU

--- a/packages/framework/ini-files/supported-envs.ini
+++ b/packages/framework/ini-files/supported-envs.ini
@@ -145,8 +145,8 @@ sems-gnu-7.2.0-anaconda3-serial:
     gnu-7.2.0-anaconda3-nompi
 sems-gnu-7.2.0-openmpi-1.10.1-serial:
     gnu-7.2.0
-sems-gnu-7.2.0-serial:
-    gnu-7.2.0-nompi
+sems-gnu-8.3.0-serial:
+    gnu-8.3.0-nompi
 sems-gnu-8.3.0-openmpi-1.10.1-serial:
     gnu-8.3.0
 sems-gnu-8.3.0-openmpi-1.10.1-openmp:


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Needed for monitoring nightly gcc-8.3.0-serial C++17 build.



## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
```
$ source ../packages/framework/GenConfig/gen-config.sh --cmake-fragment TRILFRAME-403.cmake rhel7_sems-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_all ../
(rhel7_sems-gnu-8.3.0-serial) $ cmake -C TRILFRAME-403.cmake ../
<snip>
 -- Build files have been written to: /scratch/eharvey/Trilinos/build
(rhel7_sems-gnu-8.3.0-serial) $ grep -i enable_all CMakeCache.txt 
Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES:BOOL=ON
Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON
Trilinos_ENABLE_ALL_PACKAGES:BOOL=ON
```

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->